### PR TITLE
Update docs for `path` and `history`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Returns the stream.
 
 Returns a pretty String interpretation of the File. Useful for console.log.
 
+### path
+
+Absolute pathname string or `undefined`. Setting to a different value pushes the old value to `history`.
+
 ### relative
 
 Returns path.relative for the file base and file path.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ var file = new File({
 console.log(file.relative); // file.coffee
 ```
 
+### history
+
+Array of `path` values the file object has had, from `history[0]` (original) through `history[history.length - 1]` (current). `history` and its elements should normally be treated as read-only and only altered indirectly by setting `path`.
+
 [npm-url]: https://npmjs.org/package/vinyl
 [npm-image]: https://badge.fury.io/js/vinyl.png
 [travis-url]: https://travis-ci.org/wearefractal/vinyl

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Default: `options.cwd`
 Full path to the file.
 
 Type: `String`  
-Default: `null`
+Default: `undefined`
 
 #### options.stat
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ Full path to the file.
 Type: `String`  
 Default: `undefined`
 
+#### options.history
+
+Path history. Has no effect if `options.path` is passed.
+
+Type: `Array`  
+Default: `options.path ? [options.path] : []`
+
 #### options.stat
 
 The result of an fs.stat call. See [fs.Stats](http://nodejs.org/api/fs.html#fs_class_fs_stats) for more information.


### PR DESCRIPTION
Fix #47.
* Document `path`
* Document `history`
* Document `options.history`
* The `options.path` documentation said the default value is `null`, but in reality it's `undefined`. I updated the documentation to reflect that. Or does the default value actually need to be `null`?