### PR TITLE
Fix file clone options

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ File.prototype.clone = function(opt) {
     };
   } else if (!opt) {
     opt = {
-      deep: false,
+      deep: true,
       contents: true
     };
   } else {

--- a/test/File.js
+++ b/test/File.js
@@ -338,7 +338,7 @@ describe('File', function() {
       file2.cwd.should.equal(file.cwd);
       file2.base.should.equal(file.base);
       file2.path.should.equal(file.path);
-      file2.custom.should.equal(file.custom);
+      file2.custom.should.not.equal(file.custom);
       file2.custom.a.should.equal(file.custom.a);
 
       done();


### PR DESCRIPTION
According to [docs](https://github.com/danielhusar/vinyl#cloneopt) custom attributes should be deep cloned by default, but they are not at the moment.