### PR TITLE
use Buffer.isBuffer instead of instanceof

### DIFF
--- a/lib/isBuffer.js
+++ b/lib/isBuffer.js
@@ -2,6 +2,4 @@ var buf = require('buffer');
 var Buffer = buf.Buffer;
 
 // could use Buffer.isBuffer but this is the same exact thing...
-module.exports = function(o) {
-  return typeof o === 'object' && o instanceof Buffer;
-};
+module.exports = Buffer.isBuffer;

--- a/lib/isBuffer.js
+++ b/lib/isBuffer.js
@@ -1,4 +1,1 @@
-var buf = require('buffer');
-var Buffer = buf.Buffer;
-
-module.exports = Buffer.isBuffer;
+module.exports = require('buffer').Buffer.isBuffer;

--- a/lib/isBuffer.js
+++ b/lib/isBuffer.js
@@ -1,5 +1,4 @@
 var buf = require('buffer');
 var Buffer = buf.Buffer;
 
-// could use Buffer.isBuffer but this is the same exact thing...
 module.exports = Buffer.isBuffer;


### PR DESCRIPTION
`instanceof` [doesnt work for browserified code](https://github.com/feross/buffer#important-always-use-bufferisbuffer-instead-of-instanceof-buffer) 

So I changed this to just use Buffer.isBuffer.

probably could just remove the entire 'isBuffer' module, but I left it to be consistent with the other packages.